### PR TITLE
meson.build: fix build with gcc < 7

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,8 @@ if defaultpath == ''
 	endif
 endif
 
-add_project_arguments(
+cc = meson.get_compiler('c')
+add_project_arguments(cc.get_supported_arguments(
 	[
 		'-Wundef',
 		'-Wunused',
@@ -41,7 +42,7 @@ add_project_arguments(
 		'-D__BSD_VISIBLE',
 		'-DSEATD_VERSION="@0@"'.format(meson.project_version()),
 		'-DSEATD_DEFAULTPATH="@0@"'.format(defaultpath)
-	],
+	]),
 	language: 'c',
 )
 


### PR DESCRIPTION
Test if `-Wimplicit-fallthrough` is available before using it as it has been added only since gcc 7.1 and https://github.com/gcc-mirror/gcc/commit/81fea426da8c4687bb32e6894dc26f00ae211822 and so it will raise the following build failure with gcc < 7:

```
arm-none-linux-gnueabi-gcc: error: unrecognized command line option '-Wimplicit-fallthrough'
```

Fixes:
 - http://autobuild.buildroot.org/results/0ee6816a7cceebdafd07612677a594bdf68e0790

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>