### PR TITLE
Update meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ add_project_arguments(cc.get_supported_link_arguments(
 )
 
 if ['debugoptimized', 'release', 'minsize'].contains(get_option('buildtype'))
-	add_project_arguments('-D_FORTIFY_SOURCE=2', language: 'c')
+	add_project_arguments('-D_FORTIFY_SOURCE=3', language: 'c')
 endif
 
 if get_option('buildtype').startswith('debug')


### PR DESCRIPTION
add -D_FORTIFY_SOURCE=3 as the previous value is not working when the gcc version is.
@kennylevinsen are you sure for gcc 13 or higher version supports -D_FORTIFY_SOURCE=2 as the default c compiler might set it as -D_FORTIFY_SOURCE=3 and you have set it as -D_FORTIFY_SOURCE=2 in meson.build that might be conflicting!!