### PR TITLE
"Adjust _FORTIFY_SOURCE level based on glibc version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,8 +63,28 @@ add_project_arguments(cc.get_supported_link_arguments(
 	language: 'c',
 )
 
+# Check glibc version using compiler defines
+glibc_major = cc.get_define('__GLIBC__', prefix: '#include <features.h>')
+glibc_minor = cc.get_define('__GLIBC_MINOR__', prefix: '#include <features.h>')
+musl_check = cc.get_define('__MUSL__', prefix: '#include <features.h>')
+
+if glibc_major != '' and glibc_minor != ''
+    glibc_major_int = glibc_major.to_int()
+    glibc_minor_int = glibc_minor.to_int()
+    if glibc_major_int < 2 or (glibc_major_int == 2 and glibc_minor_int <= 35)
+        fortify_level = 2
+    else
+        fortify_level = 3
+    endif
+elif musl_check != ''
+    fortify_level = 2  # musl supports up to 2
+else
+    fortify_level = 2  # Fallback for other C libraries
+endif
+
+# Apply _FORTIFY_SOURCE level
 if ['debugoptimized', 'release', 'minsize'].contains(get_option('buildtype'))
-	add_project_arguments('-D_FORTIFY_SOURCE=2', language: 'c')
+    add_project_arguments('-D_FORTIFY_SOURCE=' + fortify_level.to_string(), language: 'c')
 endif
 
 if get_option('buildtype').startswith('debug')


### PR DESCRIPTION
Dynamically set _FORTIFY_SOURCE to 2 for glibc < 2.35 and 3 for glibc >= 2.35, avoiding redefinition errors with GCC 13’s default _FORTIFY_SOURCE=3 on modern systems like Ubuntu 24.04, while maintaining compatibility with GCC 11 and older glibc versions (e.g., Ubuntu 22.04)."
Signed-off-by: Harsha Vardhan Reddy Gangavaram <HarshaVardhanReddy.Gangavaram@amd.com>